### PR TITLE
ShareExtension 타겟 추가 및 ShareViewController 구현

### DIFF
--- a/Projects/App/InfoPlists/Info.plist
+++ b/Projects/App/InfoPlists/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>dorabangs</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Projects/App/InfoPlists/ShareExtension-Info.plist
+++ b/Projects/App/InfoPlists/ShareExtension-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppIdentifierPrefix</key>
+	<string>$(AppIdentifierPrefix)</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ShareExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationDictionaryVersion</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -4,6 +4,9 @@ import ProjectDescriptionHelpers
 let debugConfig = Path.relativeToRoot("Projects/ConfigurationFiles/debug.xcconfig")
 let releaseConfig = Path.relativeToRoot("Projects/ConfigurationFiles/release.xcconfig")
 let sharedConfig = Path.relativeToRoot("Projects/ConfigurationFiles/shared.xcconfig")
+let shareExtensionDebugConfig = Path.relativeToRoot("Projects/ConfigurationFiles/debug-ShareExtension.xcconfig")
+let shareExtensionReleaseConfig = Path.relativeToRoot("Projects/ConfigurationFiles/release-ShareExtension.xcconfig")
+let shareExtensionSharedConfig = Path.relativeToRoot("Projects/ConfigurationFiles/shared-ShareExtension.xcconfig")
 
 let project = Project.make(
     name: "App",
@@ -16,7 +19,8 @@ let project = Project.make(
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             dependencies: [
-                .coordinator(.app)
+                .coordinator(.app),
+                .shareExtension(.prod)
             ],
             settings: .settings(
                 configurations: [.release(name: .release, xcconfig: releaseConfig)]
@@ -30,12 +34,36 @@ let project = Project.make(
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             dependencies: [
-                .coordinator(.app)
+                .coordinator(.app),
+                .shareExtension(.dev)
             ],
             settings: .settings(
                 configurations: [.debug(name: .debug, xcconfig: debugConfig)]
             )
+        ),
+        .make(
+            name: "Prod-ShareExtension",
+            product: .appExtension,
+            bundleId: "com.mashup.dorabangs.share",
+            infoPlist: .file(path: .relativeToRoot("Projects/App/InfoPlists/ShareExtension-Info.plist")),
+            sources: ["ShareExtension/**"],
+            dependencies: [.designSystem],
+            settings: .settings(
+                configurations: [.release(name: .release, xcconfig: shareExtensionReleaseConfig)]
+            )
+        ),
+        .make(
+            name: "Dev-ShareExtension",
+            destinations: .iOS,
+            product: .appExtension,
+            bundleId: "com.mashup.dorabangs-dev.share",
+            infoPlist: .file(path: .relativeToRoot("Projects/App/InfoPlists/ShareExtension-Info.plist")),
+            sources: ["ShareExtension/**"],
+            dependencies: [.designSystem],
+            settings: .settings(
+                configurations: [.debug(name: .debug, xcconfig: shareExtensionDebugConfig)]
+            )
         )
     ],
-    additionalFiles: [.glob(pattern: sharedConfig)]
+    additionalFiles: [.glob(pattern: sharedConfig), .glob(pattern: shareExtensionSharedConfig)]
 )

--- a/Projects/App/ShareExtension/ShareViewController.swift
+++ b/Projects/App/ShareExtension/ShareViewController.swift
@@ -1,0 +1,133 @@
+//
+//  ShareViewController.swift
+//  ShareExtension
+//
+//  Created by 김영균 on 7/1/24.
+//
+
+import DesignSystemKit
+import UIKit
+
+final class ShareViewController: UIViewController {
+    private let stackView = UIStackView()
+    private let descriptionLabel = UILabel()
+    private let editButton = UIButton()
+    private let divider = UIView()
+    private var url: URL?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setViewHierarchies()
+        setViewConstraints()
+        setViewAttributes()
+    }
+}
+
+// 출처: https://forums.swift.org/t/how-to-use-non-sendable-type-in-async-reducer-code/62069/6
+extension NSItemProvider: @unchecked Sendable {}
+private extension ShareViewController {
+    func loadSharedURL() async -> URL? {
+        let extensionItem = extensionContext?.inputItems.first as? NSExtensionItem
+        let itemProvider = extensionItem?.attachments?.first
+        guard let itemProvider, itemProvider.hasItemConformingToTypeIdentifier("public.url") else {
+            return nil
+        }
+        return try? await itemProvider.loadItem(forTypeIdentifier: "public.url") as? URL
+    }
+
+    @objc
+    func editButtonDidTapped() {
+        if let url, let appURL = URL(string: "dorabangs://?url=\(url.absoluteString)") {
+            open(url: appURL)
+            extensionContext?.completeRequest(returningItems: nil)
+        } else {
+            Task { [weak self] in
+                guard
+                    let url = await self?.loadSharedURL(),
+                    let appURL = URL(string: "dorabangs://?url=\(url.absoluteString)")
+                else {
+                    return
+                }
+                self?.open(url: appURL)
+                self?.extensionContext?.completeRequest(returningItems: nil)
+            }
+        }
+    }
+
+    // 출처 : https://liman.io/blog/open-url-share-extension-swiftui
+    private func open(url: URL) {
+        var responder: UIResponder? = self as UIResponder
+        let selector = #selector(openURL(_:))
+
+        while let currentResponder = responder {
+            if currentResponder != self, currentResponder.responds(to: selector) {
+                currentResponder.perform(selector, with: url)
+                return
+            }
+            responder = currentResponder.next
+        }
+    }
+
+    @objc
+    private func openURL(_: URL) {}
+}
+
+// MARK: - View Methods
+
+private extension ShareViewController {
+    func setViewHierarchies() {
+        view.addSubview(stackView)
+        stackView.addArrangedSubview(descriptionLabel)
+        stackView.addArrangedSubview(divider)
+        stackView.addArrangedSubview(editButton)
+    }
+
+    func setViewConstraints() {
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            divider.widthAnchor.constraint(equalToConstant: 1),
+            divider.heightAnchor.constraint(equalToConstant: 21.5)
+        ])
+    }
+
+    func setViewAttributes() {
+        setStackViewAttributes()
+        setDescriptionLabelAttributes()
+        setEditButtonAttributes()
+        setDividerAttributes()
+    }
+
+    func setStackViewAttributes() {
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .equalSpacing
+        stackView.backgroundColor = DesignSystemKitAsset.Colors.g9.color
+        stackView.directionalLayoutMargins = .init(top: 16, leading: 12, bottom: 16, trailing: 12)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layer.cornerRadius = 8
+        stackView.layer.masksToBounds = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    func setDescriptionLabelAttributes() {
+        descriptionLabel.text = "나중에 읽을 링크에 저장했어요!"
+        descriptionLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+        descriptionLabel.textColor = .white
+    }
+
+    func setEditButtonAttributes() {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = DesignSystemKitAsset.Colors.white.color
+        var container = AttributeContainer()
+        container.font = .systemFont(ofSize: 18, weight: .semibold)
+        configuration.attributedTitle = AttributedString("편집", attributes: container)
+        editButton.configuration = configuration
+        editButton.addTarget(self, action: #selector(editButtonDidTapped), for: .touchUpInside)
+    }
+
+    func setDividerAttributes() {
+        divider.backgroundColor = .white
+    }
+}

--- a/Projects/App/Sources/DorabangsApp.swift
+++ b/Projects/App/Sources/DorabangsApp.swift
@@ -13,17 +13,23 @@ import SwiftUI
 
 @main
 struct DorabangsApp: App {
+    private let store: StoreOf<AppCoordinator> = .init(initialState: .initialState) {
+        AppCoordinator()
+    }
+
     init() {
         try? DesignSystemKitAsset.Typography.registerFont()
     }
 
     var body: some Scene {
         WindowGroup {
-            AppCoordinatorView(
-                store: Store(initialState: .initialState) {
-                    AppCoordinator()
+            AppCoordinatorView(store: store)
+                .onOpenURL { url in
+                    let urlcomponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let queryItems = urlcomponents?.queryItems
+                    guard let saveURL = queryItems?.first(where: { $0.name == "url" })?.value else { return }
+                    store.send(.saveURL(saveURL))
                 }
-            )
         }
     }
 }

--- a/Projects/ConfigurationFiles/debug-ShareExtension.xcconfig
+++ b/Projects/ConfigurationFiles/debug-ShareExtension.xcconfig
@@ -1,0 +1,16 @@
+//
+//  debug-ShareExtension.xcconfig
+//  App
+//
+//  Created by 김영균 on 7/1/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+#include "./shared-ShareExtension.xcconfig"
+
+PROVISIONING_PROFILE_SPECIFIER = Development com.mashup.dorabangs-dev.share
+
+CODE_SIGN_IDENTITY = Apple Development: YoungGyun Kim (N9J5978KH3)

--- a/Projects/ConfigurationFiles/debug.xcconfig
+++ b/Projects/ConfigurationFiles/debug.xcconfig
@@ -18,4 +18,4 @@ BUNDLE_NAME = [DEV]링킷
 
 PROVISIONING_PROFILE_SPECIFIER = Development com.mashup.dorabangs-dev
 
-CODE_SIGN_IDENTITY = Apple Development: YoungGyun Kim (8ATYCP492F)
+CODE_SIGN_IDENTITY = Apple Development: YoungGyun Kim (N9J5978KH3)

--- a/Projects/ConfigurationFiles/release-ShareExtension.xcconfig
+++ b/Projects/ConfigurationFiles/release-ShareExtension.xcconfig
@@ -1,0 +1,16 @@
+//
+//  release-ShareExtension.xcconfig
+//  App
+//
+//  Created by 김영균 on 7/1/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+#include "./shared-ShareExtension.xcconfig"
+
+PROVISIONING_PROFILE_SPECIFIER = Distribution com.mashup.dorabangs.share
+
+CODE_SIGN_IDENTITY = Apple Distribution: YoungGyun Kim (8ATYCP492F)

--- a/Projects/ConfigurationFiles/shared-ShareExtension.xcconfig
+++ b/Projects/ConfigurationFiles/shared-ShareExtension.xcconfig
@@ -1,0 +1,20 @@
+//
+//  shared-ShareExtension.xcconfig
+//  App
+//
+//  Created by 김영균 on 7/1/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+MARKETING_VERSION = 1.0.0
+
+CURRENT_PROJECT_VERSION = 1.0
+
+IPHONEOS_DEPLOYMENT_TARGET = 15.0
+
+DEVELOPMENT_TEAM = 8ATYCP492F
+
+CODE_SIGN_STYLE = Manual

--- a/Projects/Features/Coordinator/AppCoordinator/AppCoordinator.swift
+++ b/Projects/Features/Coordinator/AppCoordinator/AppCoordinator.swift
@@ -33,6 +33,7 @@ public struct AppCoordinator {
 
     public enum Action {
         case router(IndexedRouterActionOf<AppScreen>)
+        case saveURL(String)
     }
 
     public init() {}
@@ -40,6 +41,8 @@ public struct AppCoordinator {
     public var body: some ReducerOf<Self> {
         Reduce { _, action in
             switch action {
+            case let .saveURL(url):
+                .send(.router(.routeAction(id: 0, action: .tabCoordinator(.saveURL(url)))))
             default:
                 .none
             }

--- a/Projects/Features/Coordinator/HomeCoordinator/HomeCoordinator.swift
+++ b/Projects/Features/Coordinator/HomeCoordinator/HomeCoordinator.swift
@@ -31,6 +31,7 @@ public struct HomeCoordinator {
 
     public enum Action {
         case router(IndexedRouterActionOf<HomeScreen>)
+        case saveURL(String)
     }
 
     public init() {}

--- a/Projects/Features/Coordinator/TabCoordinator/TabCoordinator.swift
+++ b/Projects/Features/Coordinator/TabCoordinator/TabCoordinator.swift
@@ -44,6 +44,7 @@ public struct TabCoordinator {
         case home(HomeCoordinator.Action)
         case storageBox(StorageBoxCoordinator.Action)
         case tabSelected(Tab)
+        case saveURL(String)
     }
 
     public init() {}
@@ -57,6 +58,9 @@ public struct TabCoordinator {
         }
         Reduce { state, action in
             switch action {
+            case let .saveURL(url):
+                return .send(.home(.saveURL(url)))
+
             case .home:
                 return .none
 

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -6,6 +6,7 @@ public enum Module {
 	case designSystem
 	case scene(Scene)
 	case spm(SPM)
+	case shareExtension(ShareExtension)
 }
 
 public enum Core: String {
@@ -36,6 +37,11 @@ public enum SPM: String {
 	case tcaCoordinators = "TCACoordinators"
 }
 
+public enum ShareExtension: String {
+	case dev = "Dev-ShareExtension"
+	case prod = "Prod-ShareExtension"
+}
+
 extension Module {
 	public func asTargetDependency() -> TargetDependency {
 		switch self {
@@ -53,7 +59,9 @@ extension Module {
 			
 		case .spm(let spm):
 			return .external(name: spm.rawValue)
-			
+		
+		case .shareExtension(let shareExtension):
+			return .target(name: shareExtension.rawValue)
 		}
 	}
 }


### PR DESCRIPTION
### 연관 이슈
- close #37 

### 작업 내용
- 액티비티 뷰에서 앱 선택하고 이동하도록 구현
- AppCoordinator에서 SaveURL 액션으로 하위 코디네이터까지 URL 전달합니다

### 스크린샷
https://github.com/mash-up-kr/Dorabangs_iOS/assets/48887389/17b47baa-fa2d-4159-80b6-620730354008