### PR TITLE
네트워크 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 ### macOS ###
+Secrets.swift
+
 # General
 .DS_Store
 .AppleDouble

--- a/Projects/Core/Project.swift
+++ b/Projects/Core/Project.swift
@@ -24,7 +24,9 @@ let project = Project.make(
             bundleId: "com.mashup.dorabangs.services",
             sources: ["Services/**"],
             dependencies: [
+                .spm(.alamofire),
                 .spm(.composableArchitecture),
+                .spm(.keychainAccess),
                 .core(.model)
             ]
         )

--- a/Projects/Core/Services/KeychainClient.swift
+++ b/Projects/Core/Services/KeychainClient.swift
@@ -1,0 +1,57 @@
+//
+//  KeychainClient.swift
+//  Services
+//
+//  Created by 김영균 on 7/8/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Dependencies
+import DependenciesMacros
+import Foundation
+import KeychainAccess
+
+// MARK: - Interface
+@DependencyClient
+public struct KeychainClient: Sendable {
+    public var setBool: @Sendable (Bool, String) -> Void
+    public var setString: @Sendable (String, String) -> Void
+    public var boolForKey: @Sendable (String) -> Bool = { _ in false }
+    public var stringForKey: @Sendable (String) -> String?
+    public var remove: @Sendable (String) -> Void
+}
+
+enum KeychainKey {
+    static let accessToken = "accessToken"
+}
+
+public extension KeychainClient {
+    var accessToken: String? {
+        stringForKey(KeychainKey.accessToken)
+    }
+
+    func setAccessToken(_ assessToken: String) {
+        setString(assessToken, KeychainKey.accessToken)
+    }
+}
+
+public extension DependencyValues {
+    var keychainClient: KeychainClient {
+        get { self[KeychainClient.self] }
+        set { self[KeychainClient.self] = newValue }
+    }
+}
+
+// MARK: - Live
+extension KeychainClient: DependencyKey {
+    public static var liveValue: KeychainClient {
+        let keychain = Keychain(service: "com.mashup.dorabangs")
+        return KeychainClient(
+            setBool: { keychain[$1] = $0 ? "true" : "false" },
+            setString: { keychain[$1] = $0 },
+            boolForKey: { keychain[$0] == "true" },
+            stringForKey: { keychain[$0] },
+            remove: { keychain[$0] = nil }
+        )
+    }
+}

--- a/Projects/Core/Services/NetworkFoundation/APIRepresentable.swift
+++ b/Projects/Core/Services/NetworkFoundation/APIRepresentable.swift
@@ -1,0 +1,42 @@
+//
+//  APIRepresentable.swift
+//  Services
+//
+//  Created by 김영균 on 7/6/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+public protocol APIRepresentable: URLRequestConvertible {
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var headers: HTTPHeaders? { get }
+    var queryString: Parameters? { get }
+    var httpBody: BodyParameters? { get }
+}
+
+public extension APIRepresentable {
+    func asURLRequest() throws -> URLRequest {
+        let url = try URL(target: self)
+        var urlRequest = try URLRequest(url: url, method: method)
+        urlRequest = try urlRequest.addHeaders(headers)
+        if let queryString {
+            urlRequest = try URLEncoding.queryString.encode(urlRequest, with: queryString)
+        }
+        if let httpBody {
+            urlRequest = try httpBody.encode(urlRequest)
+        }
+        return urlRequest
+    }
+}
+
+extension URLRequestConvertible {
+    func addHeaders(_ headers: HTTPHeaders?) throws -> URLRequest {
+        var urlRequest = try asURLRequest()
+        guard let headers else { return urlRequest }
+        urlRequest.headers = headers
+        return urlRequest
+    }
+}

--- a/Projects/Core/Services/NetworkFoundation/BaseResponse.swift
+++ b/Projects/Core/Services/NetworkFoundation/BaseResponse.swift
@@ -1,0 +1,81 @@
+//
+//  BaseResponse.swift
+//  Services
+//
+//  Created by 김영균 on 7/7/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Foundation
+
+public struct DataResponse<T: Decodable>: Decodable {
+    public let success: Bool
+    public let data: T?
+}
+
+public struct ErrorResponse: Decodable {
+    public let success: Bool
+    public let error: Error
+
+    public struct Error: Decodable {
+        public let code: String
+        public let message: Message
+
+        public struct Message: Decodable {
+            public let message: String
+            public let statusCode: Int
+        }
+    }
+}
+
+extension DataResponse {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        success = try container.decode(Bool.self, forKey: .success)
+        data = try container.decode(T.self, forKey: .data)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case success
+        case data
+    }
+}
+
+extension ErrorResponse {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        success = try container.decode(Bool.self, forKey: .success)
+        error = try container.decode(Error.self, forKey: .error)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case success
+        case error
+    }
+}
+
+extension ErrorResponse.Error {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        code = try container.decode(String.self, forKey: .code)
+        message = try container.decode(Message.self, forKey: .message)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case message
+    }
+}
+
+extension ErrorResponse.Error.Message {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        message = try container.decode(String.self, forKey: .message)
+        statusCode = try container.decode(Int.self, forKey: .statusCode)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case message
+        case statusCode
+    }
+}

--- a/Projects/Core/Services/NetworkFoundation/BodyParameters.swift
+++ b/Projects/Core/Services/NetworkFoundation/BodyParameters.swift
@@ -1,0 +1,45 @@
+//
+//  BodyParameters.swift
+//  Services
+//
+//  Created by 김영균 on 7/6/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+public enum BodyParameters {
+    case dictionary(Parameters)
+    case encodable(Encodable)
+
+    public func asDictionary() -> [String: Any]? {
+        switch self {
+        case let .dictionary(dict):
+            dict
+
+        case let .encodable(encodable):
+            encodable.asDictionary()
+        }
+    }
+
+    public func encode(_ urlRequest: any URLRequestConvertible) throws -> URLRequest {
+        var urlRequest = try urlRequest.asURLRequest()
+
+        switch self {
+        case let .dictionary(dict):
+            urlRequest = try JSONEncoding.default.encode(urlRequest, with: dict)
+
+        case let .encodable(encodable):
+            urlRequest = try JSONEncoding.default.encode(urlRequest, with: encodable.asDictionary())
+        }
+        return urlRequest
+    }
+}
+
+extension Encodable {
+    func asDictionary() -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
+    }
+}

--- a/Projects/Core/Services/NetworkFoundation/Provider.swift
+++ b/Projects/Core/Services/NetworkFoundation/Provider.swift
@@ -1,0 +1,80 @@
+//
+//  Provider.swift
+//  Services
+//
+//  Created by 김영균 on 7/7/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+public struct Provider {
+    private let session: Session
+    private let requestHeaderInterceptor: RequestInterceptor = RequestHeaderInterceptor()
+
+    public init(session: Session = .default) {
+        self.session = session
+    }
+
+    public func request<T: Decodable>(_ api: APIRepresentable) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            session.request(api, interceptor: requestHeaderInterceptor).responseData { response in
+                switch response.result {
+                case let .success(data):
+                    do {
+                        try processSuccessResponse(response: response, data: data, continuation: continuation)
+                    } catch {
+                        continuation.resume(throwing: NetworkError.decodingError(error))
+                    }
+                case let .failure(error):
+                    continuation.resume(throwing: NetworkError.underlying(error))
+                }
+            }
+        }
+    }
+}
+
+private extension Provider {
+    func processSuccessResponse<T: Decodable>(response: AFDataResponse<Data>, data: Data, continuation: CheckedContinuation<T, Error>) throws {
+        if let httpResponse = response.response, 200 ..< 400 ~= httpResponse.statusCode {
+            let decodedResponse = try JSONDecoder().decode(DataResponse<T>.self, from: data)
+            if let responseData = decodedResponse.data {
+                continuation.resume(returning: responseData)
+            } else {
+                continuation.resume(throwing: NetworkError.noData)
+            }
+        } else {
+            try handleErrorResponse(data: data, continuation: continuation)
+        }
+    }
+
+    func handleErrorResponse(data: Data, continuation: CheckedContinuation<some Decodable, Error>) throws {
+        let decodedError = try JSONDecoder().decode(ErrorResponse.self, from: data)
+        let errorMessage = decodedError.error.message
+        continuation.resume(throwing: NetworkError.invalidResponse(statusCode: errorMessage.statusCode, message: errorMessage.message))
+    }
+}
+
+public enum NetworkError: Error {
+    case underlying(AFError)
+    case invalidResponse(statusCode: Int, message: String)
+    case noData
+    case decodingError(Error)
+
+    var localizedDescription: String {
+        switch self {
+        case let .underlying(error):
+            error.localizedDescription
+
+        case let .invalidResponse(_, message):
+            message
+
+        case .noData:
+            "No data available"
+
+        case let .decodingError(error):
+            "Decoding error: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Projects/Core/Services/NetworkFoundation/RequestInterceptor.swift
+++ b/Projects/Core/Services/NetworkFoundation/RequestInterceptor.swift
@@ -1,0 +1,26 @@
+//
+//  RequestInterceptor.swift
+//  Services
+//
+//  Created by 김영균 on 7/7/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+final class RequestHeaderInterceptor: RequestInterceptor {
+    private let keyChainClient: KeychainClient
+
+    init(keyChainClient: KeychainClient = .liveValue) {
+        self.keyChainClient = keyChainClient
+    }
+
+    func adapt(_ urlRequest: URLRequest, for _: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var urlRequest = urlRequest
+        if let accessToken = keyChainClient.accessToken {
+            urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        }
+        completion(.success(urlRequest))
+    }
+}

--- a/Projects/Core/Services/NetworkFoundation/Secrets.swift
+++ b/Projects/Core/Services/NetworkFoundation/Secrets.swift
@@ -1,0 +1,13 @@
+//
+//  Secrets.swift
+//  Services
+//
+//  Created by 김영균 on 7/7/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Foundation
+
+enum Secrets {
+    static let baseURL = ""
+}

--- a/Projects/Core/Services/NetworkFoundation/URL+init.swift
+++ b/Projects/Core/Services/NetworkFoundation/URL+init.swift
@@ -1,0 +1,24 @@
+//
+//  URL+init.swift
+//  Services
+//
+//  Created by 김영균 on 7/6/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+extension URL {
+    init(target: some APIRepresentable) throws {
+        let path = target.path
+        guard let baseURL = URL(string: Secrets.baseURL) else {
+            throw AFError.invalidURL(url: Secrets.baseURL)
+        }
+        if path.isEmpty {
+            self = baseURL
+        } else {
+            self = baseURL.appendingPathComponent(path)
+        }
+    }
+}

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
+      "state" : {
+        "revision" : "61cf758b1b58e3b1bbecb97bb7b4a2ede5817bb3",
+        "version" : "4.0.0"
+      }
+    },
+    {
       "identity" : "swift-case-paths",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -8,7 +8,8 @@ import PackageDescription
         productTypes: [
             "Alamofire": .framework,
             "ComposableArchitecture": .framework,
-            "TCACoordinators": .framework
+			"TCACoordinators": .framework,
+			"KeychainAccess": .framework
         ]
     )
 #endif
@@ -18,6 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.11.0"),
         .package(url: "https://github.com/johnpatrickmorgan/TCACoordinators", exact: "0.10.1"),
-        .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.9.1")
+        .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.9.1"),
+		.package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", exact: "4.0.0")
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -39,6 +39,7 @@ public enum SPM: String {
 	case alamofire = "Alamofire"
 	case composableArchitecture = "ComposableArchitecture"
 	case tcaCoordinators = "TCACoordinators"
+	case keychainAccess = "KeychainAccess"
 }
 
 public enum ShareExtension: String {


### PR DESCRIPTION
### 연관 이슈
- close #27 

### 작업 내용
프로젝트에서 사용할 네트워크 구현
  
API가 udid로 AccessToken을 받아오는 구조이길래 udid 저장 겸 토큰 관리하려고 키체인 사용했습니다.

`APIRepresentable` 채택해서 api endpoint 정의하면 됩니다.
