### PR TITLE
토스트 메세지가 탭 바에 가려지는 버그 수정

### DIFF
--- a/Projects/Features/Scene/HomeScene/HomeContainerView.swift
+++ b/Projects/Features/Scene/HomeScene/HomeContainerView.swift
@@ -27,8 +27,22 @@ public struct HomeContainerView<Content: View>: View {
             HomeView(store: store)
             tabbar()
         }
+        .clipboardToast(store: store.scope(state: \.clipboardToast, action: \.clipboardToast))
         .navigationBarHidden(true)
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func clipboardToast(store: StoreOf<ClipboardToastFeature>) -> some View {
+        @Perception.Bindable var store = store
+        clipboardToast(
+            isPresented: $store.isPresented.sending(\.isPresentedChanged),
+            urlString: store.shared.urlString,
+            saveAction: { store.send(.saveButtonTapped) },
+            closeAction: { store.send(.closeButtonTapped) }
+        )
     }
 }

--- a/Projects/Features/Scene/HomeScene/HomeView.swift
+++ b/Projects/Features/Scene/HomeScene/HomeView.swift
@@ -67,7 +67,6 @@ public struct HomeView: View {
                 guard newValue == .active else { return }
                 checkClipboardURL()
             }
-            .clipboardToast(store: store.scope(state: \.clipboardToast, action: \.clipboardToast))
         }
     }
 
@@ -76,18 +75,5 @@ public struct HomeView: View {
             store.send(.clipboardURLChanged(url))
             UIPasteboard.general.url = nil
         }
-    }
-}
-
-private extension View {
-    @ViewBuilder
-    func clipboardToast(store: StoreOf<ClipboardToastFeature>) -> some View {
-        @Perception.Bindable var store = store
-        clipboardToast(
-            isPresented: $store.isPresented.sending(\.isPresentedChanged),
-            urlString: store.shared.urlString,
-            saveAction: { store.send(.saveButtonTapped) },
-            closeAction: { store.send(.closeButtonTapped) }
-        )
     }
 }


### PR DESCRIPTION
### 연관 이슈
- close #68 

### 작업 내용
홈 컨테이너 뷰에서 토스트 메세지를 보여줌!

### 스크린샷 (선택)
<img width="561" alt="image" src="https://github.com/mash-up-kr/Dorabangs_iOS/assets/48887389/da91ac66-b113-40dd-a14e-4dd851f2fbbd">
