### PR TITLE
피드 관련 API 연동 (#96)

### DIFF
--- a/Projects/Core/Models/Card.swift
+++ b/Projects/Core/Models/Card.swift
@@ -8,6 +8,18 @@
 
 import Foundation
 
+public struct CardListModel {
+    public let hasNext: Bool
+    public let total: Int
+    public let cards: [Card]
+
+    public init(hasNext: Bool, total: Int, cards: [Card]) {
+        self.hasNext = hasNext
+        self.total = total
+        self.cards = cards
+    }
+}
+
 public struct Card: Hashable {
     public let id: String
     public let folderId: String

--- a/Projects/Core/Services/AIClassificationAPI/AIClassificationAPI.swift
+++ b/Projects/Core/Services/AIClassificationAPI/AIClassificationAPI.swift
@@ -44,12 +44,12 @@ extension AIClassificationAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: Parameters? {
+    var queryString: QueryStringParameters? {
         switch self {
         case .getFolders: .none
-        case let .getPosts(_, page): ["page": page]
+        case let .getPosts(_, page): .dictionary(["page": page])
         case .deletePost: .none
-        case let .patchPosts(suggestionFolderId): ["suggestionFolderId": suggestionFolderId]
+        case let .patchPosts(suggestionFolderId): .dictionary(["suggestionFolderId": suggestionFolderId])
         }
     }
 

--- a/Projects/Core/Services/FolderAPI/FolderAPI.swift
+++ b/Projects/Core/Services/FolderAPI/FolderAPI.swift
@@ -49,7 +49,17 @@ extension FolderAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: QueryStringParameters? { nil }
+    var queryString: QueryStringParameters? {
+        switch self {
+        case let .getFolderPosts(_, page, limit, order, unread):
+            .dictionary(["page": page,
+                         "limit": limit,
+                         "order": order,
+                         "unread": unread])
+        default:
+            nil
+        }
+    }
 
     var httpBody: BodyParameters? {
         switch self {

--- a/Projects/Core/Services/FolderAPI/FolderAPI.swift
+++ b/Projects/Core/Services/FolderAPI/FolderAPI.swift
@@ -15,7 +15,7 @@ enum FolderAPI: APIRepresentable {
     /// 폴더 리스트 조회
     case getFolders
     case postFolders(folders: [String])
-    case getFolderPosts(folderId: String, page: Int?, limit: Int?, unread: Bool?)
+    case getFolderPosts(folderId: String, page: Int?, limit: Int?, order: String?, unread: Bool?)
     case deleteFolder(folderId: String)
     case patchFolder(folderId: String, newName: String)
 }
@@ -27,7 +27,7 @@ extension FolderAPI {
             "/folders/\(folderId)"
         case .getFolders, .postFolders:
             "/folders"
-        case let .getFolderPosts(folderId, page, limit, unread):
+        case let .getFolderPosts(folderId, _, _, _, _):
             "/folders/\(folderId)/posts"
         case let .deleteFolder(folderId), let .patchFolder(folderId, _):
             "/folders/\(folderId)"

--- a/Projects/Core/Services/FolderAPI/FolderAPI.swift
+++ b/Projects/Core/Services/FolderAPI/FolderAPI.swift
@@ -49,7 +49,7 @@ extension FolderAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: Parameters? { nil }
+    var queryString: QueryStringParameters? { nil }
 
     var httpBody: BodyParameters? {
         switch self {

--- a/Projects/Core/Services/FolderAPI/FolderAPIClient.swift
+++ b/Projects/Core/Services/FolderAPI/FolderAPIClient.swift
@@ -20,8 +20,9 @@ public struct FolderAPIClient {
         _ folderId: String,
         _ page: Int?,
         _ limit: Int?,
+        _ order: String?,
         _ unread: Bool?
-    ) async throws -> [Card]
+    ) async throws -> CardListModel
     public var deleteFolder: @Sendable (String) async throws -> Void
     public var patchFolder: @Sendable (String, String) async throws -> Folder
 }
@@ -53,11 +54,11 @@ extension FolderAPIClient: DependencyKey {
             let api = FolderAPI.postFolders(folders: folders)
             let responseDTO: EmptyResponseDTO = try await Provider().request(api)
         },
-        getFolderPosts: { folderId, page, limit, unread in
-            let api = FolderAPI.getFolderPosts(folderId: folderId, page: page, limit: limit, unread: unread)
+        getFolderPosts: { folderId, page, limit, order, unread in
+            let api = FolderAPI.getFolderPosts(folderId: folderId, page: page, limit: limit, order: order, unread: unread)
             let responseDTO: GetFolderPostsResponseDTO = try await Provider().request(api)
             let cardList = responseDTO.list.map(\.toDomain)
-            return cardList
+            return CardListModel(hasNext: responseDTO.hasNext, total: responseDTO.total, cards: cardList)
         },
         deleteFolder: { folderId in
             let api = FolderAPI.deleteFolder(folderId: folderId)

--- a/Projects/Core/Services/LinkAPI/LinkAPI.swift
+++ b/Projects/Core/Services/LinkAPI/LinkAPI.swift
@@ -26,10 +26,10 @@ extension LinkAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: Parameters? {
+    var queryString: QueryStringParameters? {
         switch self {
         case let .getValidation(link):
-            ["link": link]
+            .dictionary(["link": link])
         }
     }
 

--- a/Projects/Core/Services/NetworkFoundation/APIRepresentable.swift
+++ b/Projects/Core/Services/NetworkFoundation/APIRepresentable.swift
@@ -13,7 +13,7 @@ public protocol APIRepresentable: URLRequestConvertible {
     var path: String { get }
     var method: HTTPMethod { get }
     var headers: HTTPHeaders? { get }
-    var queryString: Parameters? { get }
+    var queryString: QueryStringParameters? { get }
     var httpBody: BodyParameters? { get }
 }
 
@@ -23,7 +23,7 @@ public extension APIRepresentable {
         var urlRequest = try URLRequest(url: url, method: method)
         urlRequest = try urlRequest.addHeaders(headers)
         if let queryString {
-            urlRequest = try URLEncoding.queryString.encode(urlRequest, with: queryString)
+            urlRequest = try queryString.encode(urlRequest)
         }
         if let httpBody {
             urlRequest = try httpBody.encode(urlRequest)

--- a/Projects/Core/Services/NetworkFoundation/QueryStringParameters.swift
+++ b/Projects/Core/Services/NetworkFoundation/QueryStringParameters.swift
@@ -29,7 +29,7 @@ public enum QueryStringParameters {
         switch self {
         case let .dictionary(dict):
             let nilFilteredDictionary = filterNilValues(from: dict)
-            urlRequest = try URLEncoding.queryString.encode(urlRequest, with: dict)
+            urlRequest = try URLEncoding.queryString.encode(urlRequest, with: nilFilteredDictionary)
 
         case let .encodable(encodable):
             let nilFilteredDictionary = filterNilValues(from: encodable.asDictionary())
@@ -39,14 +39,7 @@ public enum QueryStringParameters {
     }
 
     // 딕셔너리에서 nil 값을 필터링하는 함수
-    func filterNilValues(from dictionary: [String: Any]?) -> [String: Any] {
-        guard let dictionary else { return [:] }
-        var filteredDictionary = [String: Any]()
-        for (key, value) in dictionary {
-            if !(value is NSNull) {
-                filteredDictionary[key] = value
-            }
-        }
-        return filteredDictionary
+    func filterNilValues(from dictionary: [String: Any?]?) -> [String: Any] {
+        dictionary?.compactMapValues { $0 } ?? [:]
     }
 }

--- a/Projects/Core/Services/NetworkFoundation/QueryStringParameters.swift
+++ b/Projects/Core/Services/NetworkFoundation/QueryStringParameters.swift
@@ -1,0 +1,52 @@
+//
+//  QueryStringParameters.swift
+//  Services
+//
+//  Created by 김영균 on 7/20/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Alamofire
+import Foundation
+
+public enum QueryStringParameters {
+    case dictionary(Parameters)
+    case encodable(Encodable)
+
+    public func asDictionary() -> [String: Any]? {
+        switch self {
+        case let .dictionary(dict):
+            dict
+
+        case let .encodable(encodable):
+            encodable.asDictionary()
+        }
+    }
+
+    public func encode(_ urlRequest: URLRequestConvertible) throws -> URLRequest {
+        var urlRequest = try urlRequest.asURLRequest()
+
+        switch self {
+        case let .dictionary(dict):
+            let nilFilteredDictionary = filterNilValues(from: dict)
+            urlRequest = try URLEncoding.queryString.encode(urlRequest, with: dict)
+
+        case let .encodable(encodable):
+            let nilFilteredDictionary = filterNilValues(from: encodable.asDictionary())
+            urlRequest = try URLEncoding.queryString.encode(urlRequest, with: nilFilteredDictionary)
+        }
+        return urlRequest
+    }
+
+    // 딕셔너리에서 nil 값을 필터링하는 함수
+    func filterNilValues(from dictionary: [String: Any]?) -> [String: Any] {
+        guard let dictionary else { return [:] }
+        var filteredDictionary = [String: Any]()
+        for (key, value) in dictionary {
+            if !(value is NSNull) {
+                filteredDictionary[key] = value
+            }
+        }
+        return filteredDictionary
+    }
+}

--- a/Projects/Core/Services/OnboardingAPI/OnboardingAPI.swift
+++ b/Projects/Core/Services/OnboardingAPI/OnboardingAPI.swift
@@ -20,7 +20,7 @@ extension OnboardingAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: Parameters? { nil }
+    var queryString: QueryStringParameters? { nil }
 
     var httpBody: BodyParameters? { nil }
 }

--- a/Projects/Core/Services/PostAPI/PostAPI.swift
+++ b/Projects/Core/Services/PostAPI/PostAPI.swift
@@ -50,7 +50,7 @@ extension PostAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: Parameters? { nil }
+    var queryString: QueryStringParameters? { nil }
 
     var httpBody: BodyParameters? {
         switch self {

--- a/Projects/Core/Services/UserAPI/UserAPI.swift
+++ b/Projects/Core/Services/UserAPI/UserAPI.swift
@@ -20,7 +20,7 @@ extension UserAPI {
 
     var headers: HTTPHeaders? { nil }
 
-    var queryString: Parameters? { nil }
+    var queryString: QueryStringParameters? { nil }
 
     var httpBody: BodyParameters? {
         switch self {

--- a/Projects/Features/Coordinator/FeedCoordinator/FeedCoordinator.swift
+++ b/Projects/Features/Coordinator/FeedCoordinator/FeedCoordinator.swift
@@ -9,6 +9,7 @@
 import ChangeFolderName
 import ComposableArchitecture
 import Feed
+import Models
 import TCACoordinators
 
 @Reducer(state: .equatable)
@@ -27,8 +28,8 @@ public struct FeedCoordinator {
             self.routes = routes
         }
 
-        public init(title: String) {
-            routes = [.root(.feed(.init(title: title)), embedInNavigationView: true)]
+        public init(_ folder: Folder) {
+            routes = [.root(.feed(.init(currentFolder: folder)), embedInNavigationView: true)]
         }
     }
 

--- a/Projects/Features/Coordinator/Project.swift
+++ b/Projects/Features/Coordinator/Project.swift
@@ -59,6 +59,7 @@ let project = Project.make(
             bundleId: "com.mashup.dorabangs.feedCoordinator",
             sources: ["FeedCoordinator/**"],
             dependencies: [
+                .core(.model),
                 .scene(.feed),
                 .spm(.tcaCoordinators),
                 .scene(.changeFolderName)

--- a/Projects/Features/Coordinator/StorageBoxCoordinator/StorageBoxCoordinator.swift
+++ b/Projects/Features/Coordinator/StorageBoxCoordinator/StorageBoxCoordinator.swift
@@ -40,8 +40,8 @@ public struct StorageBoxCoordinator {
         Reduce { state, action in
             switch action {
             case .router(.routeAction(id: _,
-                                      action: .storageBox(.routeToFeed(let title)))):
-                state.routes.push(.feed(.init(routes: [.root(.feed(.init(title: title)), embedInNavigationView: true)])))
+                                      action: .storageBox(.routeToFeed(let folder)))):
+                state.routes.push(.feed(.init(routes: [.root(.feed(.init(currentFolder: folder)), embedInNavigationView: true)])))
                 return .none
             case .router(.routeAction(id: _, action: .storageBox(.routeToChangeFolderName(let folderID, let folderNames)))):
                 state.routes.push(.changeFolderName(.init(folderID: folderID, folders: folderNames)))

--- a/Projects/Features/Scene/FeedScene/FeedView.swift
+++ b/Projects/Features/Scene/FeedScene/FeedView.swift
@@ -21,7 +21,7 @@ public struct FeedView: View {
         WithPerceptionTracking {
             VStack {
                 LKTextMiddleTopBar(
-                    title: store.title,
+                    title: store.currentFolder.name,
                     backButtonAction: { store.send(.backButtonTapped) },
                     rightButtomImage: DesignSystemKitAsset.Icons.icMoreGray.swiftUIImage,
                     rightButtonEnabled: true,
@@ -32,7 +32,7 @@ public struct FeedView: View {
 
                 ScrollView {
                     LazyVStack(pinnedViews: .sectionHeaders) {
-                        FeedHeaderView(folderName: store.title, linkCount: store.cards.count)
+                        FeedHeaderView(folderName: store.currentFolder.name, linkCount: store.currentFolder.postCount)
 
                         Section {
                             LazyVStack(spacing: 0) {

--- a/Projects/Features/Scene/FeedScene/FeedView.swift
+++ b/Projects/Features/Scene/FeedScene/FeedView.swift
@@ -74,26 +74,26 @@ public struct FeedView: View {
                     }
                 }
             }
-        }
-        .navigationBarHidden(true)
-        .navigationTitle("")
-        .navigationBarTitleDisplayMode(.inline)
-        .onAppear { store.send(.onAppear) }
-        .editFolderPopup(isPresented: $store.editFolderPopupIsPresented.projectedValue, onSelect: { index in
-            if index == 0 {
-                store.send(.showRemoveFolderPopup, animation: .default)
-            } else {
-                store.send(.tapChangeFolderName)
-            }
-        })
-        .modal(isPresented: $store.removeFolderPopupIsPresented.projectedValue, content: {
-            removeFolderPopup(onCancel: {
-                store.send(.cancelRemoveFolder, animation: .default)
-            }, onRemove: {
-                store.send(.tapRemoveButton)
+            .navigationBarHidden(true)
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear { store.send(.onAppear) }
+            .editFolderPopup(isPresented: $store.editFolderPopupIsPresented.projectedValue, onSelect: { index in
+                if index == 0 {
+                    store.send(.showRemoveFolderPopup, animation: .default)
+                } else {
+                    store.send(.tapChangeFolderName)
+                }
             })
-        })
-        .toast(isPresented: $store.toastPopupIsPresented, type: .info, message: "폴더 이름을 변경했어요.", isEmbedTabbar: false)
+            .modal(isPresented: $store.removeFolderPopupIsPresented.projectedValue, content: {
+                removeFolderPopup(onCancel: {
+                    store.send(.cancelRemoveFolder, animation: .default)
+                }, onRemove: {
+                    store.send(.tapRemoveButton)
+                })
+            })
+            .toast(isPresented: $store.toastPopupIsPresented, type: .info, message: "폴더 이름을 변경했어요.", isEmbedTabbar: false)
+        }
     }
 }
 

--- a/Projects/Features/Scene/FeedScene/FeedView.swift
+++ b/Projects/Features/Scene/FeedScene/FeedView.swift
@@ -57,11 +57,6 @@ public struct FeedView: View {
                                         bookMarkAction: { store.send(.bookMarkButtonTapped(index)) },
                                         showModalAction: { store.send(.showModalButtonTapped(index)) }
                                     )
-                                    .onAppear {
-                                        if index % 9 == 0 {
-                                            store.send(.fetchData)
-                                        }
-                                    }
                                 }
                             }
                         } header: {

--- a/Projects/Features/Scene/FeedScene/PostPageModel.swift
+++ b/Projects/Features/Scene/FeedScene/PostPageModel.swift
@@ -1,0 +1,34 @@
+//
+//  PostPageModel.swift
+//  Feed
+//
+//  Created by 박소현 on 7/20/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Foundation
+
+public struct PostPageModel: Equatable {
+    var currentPage: Int
+    var order: Order
+    var onlyUnread: Bool
+    var isLast: Bool
+    var isLoading: Bool
+
+    enum Order: String {
+        case ASC = "asc"
+        case DESC = "desc"
+    }
+
+    public init() {
+        currentPage = 1
+        order = .ASC
+        onlyUnread = false
+        isLast = false
+        isLoading = false
+    }
+
+    public func canLoadingMore() -> Bool {
+        !isLast && !isLoading
+    }
+}

--- a/Projects/Features/Scene/HomeScene/Home.swift
+++ b/Projects/Features/Scene/HomeScene/Home.swift
@@ -268,14 +268,15 @@ private extension Home {
     }
 
     private func handleCardList(send: Send<Home.Action>, folderId: String) async throws {
-        let cardList = try await folderAPIClient.getFolderPosts(
+        let cardListModel = try await folderAPIClient.getFolderPosts(
             folderId,
+            nil,
             nil,
             nil,
             nil
         )
 
-        await send(.setCardList(cardList))
+        await send(.setCardList(cardListModel.cards))
     }
 
     private func fetchAllCardList(send: Send<Home.Action>) async throws {

--- a/Projects/Features/Scene/StorageBoxScene/StorageBox.swift
+++ b/Projects/Features/Scene/StorageBoxScene/StorageBox.swift
@@ -54,7 +54,7 @@ public struct StorageBox {
         case changedFolderName(Folder)
 
         // MARK: Navigation Action
-        case routeToFeed(title: String)
+        case routeToFeed(Folder)
         case routeToChangeFolderName(String, [String])
 
         case binding(BindingAction<State>)
@@ -84,8 +84,8 @@ public struct StorageBox {
                 return .none
             case let .storageBoxTapped(section, folderID):
                 // TODO: - 여기 타이틀 안가지고 가도됨, id만 넘기기
-                if let title = (section == 0) ? (state.defaultFolders.first(where: { $0.id == folderID })?.name) : (state.customFolders.first(where: { $0.id == folderID })?.name) {
-                    return .send(.routeToFeed(title: title))
+                if let folder = (section == 0) ? (state.defaultFolders.first(where: { $0.id == folderID })) : (state.customFolders.first(where: { $0.id == folderID })) {
+                    return .send(.routeToFeed(folder))
                 }
                 return .none
             case let .onEdit(folderID):


### PR DESCRIPTION
### 연관 이슈
(close #96 )

### 작업 내용
- get /folders/{folderId}/posts API 수정
- queryString encode 로직 수정
- 피드 뷰에 get /folders/{folderId}/posts, get /folders/{folderId} API 연동
- PostPageModel 만듦 (필요한 데에서 쓰세여 !! )

### 스크린샷 (선택)

