### PR TITLE
get /folder/posts API 수정

### DIFF
--- a/Projects/Core/Services/FolderAPI/FolderAPI.swift
+++ b/Projects/Core/Services/FolderAPI/FolderAPI.swift
@@ -28,7 +28,8 @@ extension FolderAPI {
         case .getFolders, .postFolders:
             "/folders"
         case let .getFolderPosts(folderId, _, _, _, _):
-            "/folders/\(folderId)/posts"
+            // 전체, 즐겨찾기 탭은 folderId가 빈 문자열이다.
+            folderId.isEmpty ? "/posts" : "/folders/\(folderId)/posts"
         case let .deleteFolder(folderId), let .patchFolder(folderId, _):
             "/folders/\(folderId)"
         }

--- a/Projects/Core/Services/FolderAPI/FolderAPIClient.swift
+++ b/Projects/Core/Services/FolderAPI/FolderAPIClient.swift
@@ -58,7 +58,7 @@ extension FolderAPIClient: DependencyKey {
             let api = FolderAPI.getFolderPosts(folderId: folderId, page: page, limit: limit, order: order, unread: unread)
             let responseDTO: GetFolderPostsResponseDTO = try await Provider().request(api)
             let cardList = responseDTO.list.map(\.toDomain)
-            return CardListModel(hasNext: responseDTO.hasNext, total: responseDTO.total, cards: cardList)
+            return CardListModel(hasNext: responseDTO.metadata.hasNext, total: responseDTO.metadata.total, cards: cardList)
         },
         deleteFolder: { folderId in
             let api = FolderAPI.deleteFolder(folderId: folderId)

--- a/Projects/Core/Services/ResponseDTO/Common/AISummaryStatusDTO.swift
+++ b/Projects/Core/Services/ResponseDTO/Common/AISummaryStatusDTO.swift
@@ -1,0 +1,36 @@
+//
+//  AISummaryStatusDTO.swift
+//  Services
+//
+//  Created by 김영균 on 7/21/24.
+//  Copyright © 2024 mashup.dorabangs. All rights reserved.
+//
+
+import Foundation
+
+enum AISummaryStatusDTO: String, Decodable {
+    case success
+    case inProgress
+    case failure
+
+    enum CodingKeys: String, CodingKey {
+        case success
+        case inProgress = "in_progress"
+        case failure = "fail"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        switch value {
+        case CodingKeys.success.rawValue:
+            self = .success
+        case CodingKeys.inProgress.rawValue:
+            self = .inProgress
+        case CodingKeys.failure.rawValue:
+            self = .failure
+        default:
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid status")
+        }
+    }
+}

--- a/Projects/Core/Services/ResponseDTO/Common/CardDTO.swift
+++ b/Projects/Core/Services/ResponseDTO/Common/CardDTO.swift
@@ -20,6 +20,8 @@ struct CardDTO: Decodable {
     let createdAt: String?
     let readAt: String?
     let keywords: [KeywordDTO]?
+    let thumbnailImagUrl: String?
+    let aiStatus: AISummaryStatusDTO
 }
 
 extension CardDTO {

--- a/Projects/Core/Services/ResponseDTO/Home/GetFolderPostsResponseDTO.swift
+++ b/Projects/Core/Services/ResponseDTO/Home/GetFolderPostsResponseDTO.swift
@@ -10,6 +10,5 @@ import Foundation
 
 struct GetFolderPostsResponseDTO: Decodable {
     let list: [CardDTO]
-    let hasNext: Bool
-    let total: Int
+    let metadata: MetadataDTO
 }


### PR DESCRIPTION
### 연관 이슈
- close #118 
### 작업 내용
- `GetFolderPostsResponseDTO` 변경
- `getFolderPostsAPI` folderId에 따른 api path 분기처리


